### PR TITLE
[BUGFIX] Change jQuery data function on attr to prevent cacheable attribute data

### DIFF
--- a/Resources/Public/JavaScripts/Femanager.js
+++ b/Resources/Public/JavaScripts/Femanager.js
@@ -28,7 +28,7 @@ jQuery(document).ready(function($) {
 
 	// confirmation
 	$('*[data-confirm]').click(function(e) {
-		var message = $(this).data('confirm');
+		var message = $(this).attr('data-confirm');
 		if (!confirm(message)) {
 			e.preventDefault();
 		}

--- a/Resources/Public/JavaScripts/Validation.js
+++ b/Resources/Public/JavaScripts/Validation.js
@@ -105,7 +105,7 @@ jQuery.fn.femanagerValidation = function() {
 		$.ajax({
 			url: url,
 			data: {
-				'tx_femanager_pi1[validation]': element.data('validation'),
+				'tx_femanager_pi1[validation]': element.attr('data-validation'),
 				'tx_femanager_pi1[value]': elementValue,
 				'tx_femanager_pi1[field]': getFieldName(element),
 				'tx_femanager_pi1[user]': (user !== undefined ? user : ''),
@@ -220,7 +220,7 @@ jQuery.fn.femanagerValidation = function() {
 	 * @return array
 	 */
 	function getValidations(element) {
-		return element.data('validation').split(',');
+		return element.attr('data-validation').split(',');
 	}
 
 	/**


### PR DESCRIPTION
Because jQuery is saving data-attribute in own $.cache object. You can't in easy way external change data in attribute like data-validation because after that element.dataset has a different state then $(element).data(). 

I prefer use $.attr('data-*') instead of $.data(). Please take it to your consideration, because right now, you can't set your data-validation rule on fly without deleting $.cache object before. 