### PR TITLE
[BUGFIX] Fix autologin with reused username

### DIFF
--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -301,7 +301,7 @@ class UserUtility extends AbstractUtility
         $tsfe->fe_user->checkPid = false;
         $info = $tsfe->fe_user->getAuthInfoArray();
 
-        $extraWhere = '';
+        $extraWhere = ' AND uid = ' . (int)$user->getUid();
         if (!empty($storagePids)) {
             $extraWhere = ' AND pid IN (' . self::getDatabaseConnection()->cleanIntList($storagePids) . ')';
         }


### PR DESCRIPTION
Ensure the requested user is logged in, not the first with the same username.

Copied from https://forge.typo3.org/issues/79745