### PR TITLE
[FEATURE] add link to delete account in admin notification

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -206,7 +206,7 @@ abstract class AbstractController extends ActionController
         bool $backend = false
     ) {
         $this->loginPreflight($user, $login);
-        $variables = ['user' => $user, 'settings' => $this->settings];
+        $variables = ['user' => $user, 'settings' => $this->settings, 'hash' => HashUtility::createHashForUser($user)];
         $this->sendMailService->send(
             'createUserNotify',
             StringUtility::makeEmailArray($user->getEmail(), $user->getFirstName() . ' ' . $user->getLastName()),

--- a/Resources/Private/Templates/Email/CreateNotify.html
+++ b/Resources/Private/Templates/Email/CreateNotify.html
@@ -20,4 +20,20 @@
 
 	<p><f:translate key="emailCreateNotifyUserProperties" /></p>
 	<f:render partial="Mail/UserProperties" arguments="{_all}" />
+
+	<p>
+		<f:translate key="emailCreateAdminConfirmationText2" />
+		<br>
+		<f:link.action action="confirmCreateRequest" controller="New" absolute="1" arguments="{user:user, hash:hash, status:'adminConfirmationRefused'}">
+			<f:translate key="emailCreateAdminConfirmationLinkConfirmRefused" />
+		</f:link.action>
+	</p>
+
+	<p>
+		<f:translate key="emailCreateAdminConfirmationText3" />
+		<br>
+		<f:link.action action="confirmCreateRequest" controller="New" absolute="1" arguments="{user:user, hash:hash, status:'adminConfirmationRefusedSilent'}">
+			<f:translate key="emailCreateAdminConfirmationLinkConfirmRefusedSilent" />
+		</f:link.action>
+	</p>
 </f:section>


### PR DESCRIPTION
This patch adds the possibility for an admin to delete an account after
the user finished the double opt process.