### PR TITLE
[BUGFIX] Resolve country select list without EXT:static:info_tables

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -3,11 +3,9 @@
 namespace In2code\Femanager\DependencyInjection;
 
 use In2code\Femanager\DependencyInjection\CompilerPass\ChangeClassDatamapPass;
-use In2code\Femanager\UserFunc\StaticInfoTables;
 use SJBR\StaticInfoTables\Domain\Model\Country;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use TYPO3\CMS\Core\DependencyInjection\PublicServicePass;
 
 return function (ContainerConfigurator $configurator, ContainerBuilder $containerBuilder) {
     $containerBuilder->addCompilerPass(new ChangeClassDatamapPass());
@@ -17,12 +15,4 @@ return function (ContainerConfigurator $configurator, ContainerBuilder $containe
     $defaults->autoconfigure();
     $defaults->autowire();
     $defaults->private();
-
-    if (class_exists(Country::class)) {
-        $containerBuilder->registerForAutoconfiguration(StaticInfoTables::class)->addTag('femanager.userfunc.staticinfotables');
-        $containerBuilder->addCompilerPass(new PublicServicePass('femanager.userfunc.staticinfotables'));
-
-        $services->set(StaticInfoTables::class)
-            ->public();
-    }
 };

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -28,6 +28,8 @@ services:
       public: true
     In2code\Femanager\Finisher\FinisherRunner:
       public: true
+    In2code\Femanager\UserFunc\StaticInfoTables:
+      public: true
     In2code\Femanager\Utility\LogUtility:
       public: true
     In2code\Femanager\Domain\Service\PluginService:


### PR DESCRIPTION
The extension setting "overrideFeUserCountryFieldWithSelect" promises to activate country selection lists without requiring EXT:static_info_tables. A few minor fixes had to be applied to make it work in TYPO3 v12:

- Enable dependency injection in StaticInfoTables.php, even if EXT:static_info_tables is not installed.
- Provide selection items as ``` [] = [<label>, <iso-code>] ``` instead of ``` [<iso-code>] = <label> ``` as expected by the TCA procedures.
- Sort UTF-8 labels by using the collator of the PHP intl extension. Inspired by the TYPO3 core.
- Fetch the fully initialized language service from $GLOBALS['LANG']. Inspired by the TYPO3 core.

Fixes: #652 