### PR TITLE
Keep order of typoscript keys

### DIFF
--- a/Classes/Utility/TemplateUtility.php
+++ b/Classes/Utility/TemplateUtility.php
@@ -48,8 +48,13 @@ class TemplateUtility extends AbstractUtility
         $configuration = self::getConfigurationManager()
             ->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'femanager');
         if (!empty($configuration['view'][$part . 'RootPaths'] ?? '')) {
-            $templatePaths = $configuration['view'][$part . 'RootPaths'] ?? '';
-            $templatePaths = array_values($templatePaths);
+            // typoscript keys should be sorted here, but aren't!!
+            $unsortedTemplatePaths = $configuration['view'][$part . 'RootPaths'] ?? '';
+            $arrayKeys = array_keys($unsortedTemplatePaths);
+            sort($arrayKeys);
+            foreach ($arrayKeys as $key) {
+                $templatePaths[] = $unsortedTemplatePaths[$key];
+            }
         }
 
         if ($returnAllPaths || $templatePaths === []) {
@@ -60,7 +65,8 @@ class TemplateUtility extends AbstractUtility
 
             $templatePaths[] = 'EXT:femanager/Resources/Private/' . ucfirst($part) . 's/';
         }
-
+        // this breaks the configured order of paths by removing higher
+        // priority paths if they have lower priority duplicates
         $templatePaths = array_unique($templatePaths);
         $absolutePaths = [];
         foreach ($templatePaths as $templatePath) {


### PR DESCRIPTION
The keys in a typoscript configuration are considered to express the priority of the values.

Like in view.templateRootPaths the highest value should be used. This is not the case with the current implementation.

This might be caused by a core issue, since 
->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK, 'femanager'); should return the arrays in correct order. But it doesn't, the key depend on the order of imports of typoscript.

The Typoscript Module takes that in consideration and shows the correct order:

<img width="897" height="431" alt="Typoscript-ActiveRecord" src="https://github.com/user-attachments/assets/77348442-7000-4f1c-bc9c-52b034a0f86b" />

The configuration received in https://github.com/in2code-de/femanager/blob/74e366143cfa0290eb1517de36071d722d86626f/Classes/Utility/TemplateUtility.php#L48 has a random order:

<img width="703" height="349" alt="FrontendTypoScript-setupArray" src="https://github.com/user-attachments/assets/ce885b73-8c05-4217-8904-ad1e6cb69dbc" />

Since finally only the last entry is returned in https://github.com/in2code-de/femanager/blob/74e366143cfa0290eb1517de36071d722d86626f/Classes/Utility/TemplateUtility.php#L85 this results in a false value. It is not possible to override the value from outside

This PR restores the order by sorting the keys and returning an array of sorted entries according to the key order. 
