### PR TITLE
[BUGFIX] Support multiple values in SelectViewHelper

### DIFF
--- a/Classes/ViewHelpers/Form/SelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/SelectViewHelper.php
@@ -32,7 +32,7 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
     public function initialize(): void
     {
         parent::initialize();
-        $this->tag->addAttribute('data-selected-value', $this->getSelectedValue());
+        $this->tag->addAttribute('data-selected-value', is_array($this->getSelectedValue()) ? implode(',', $this->getSelectedValue()) : $this->getSelectedValue());
     }
 
     public function initializeArguments(): void
@@ -313,7 +313,6 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
      */
     protected function getSelectedValue()
     {
-        $selectedValues = null;
         $this->setRespectSubmittedDataValue(true);
         $value = $this->getValueAttribute();
         if (!is_array($value) && !$value instanceof \Traversable) {
@@ -321,6 +320,10 @@ class SelectViewHelper extends AbstractFormFieldViewHelper
             if ($selectedValues !== null) {
                 return $selectedValues;
             }
+        }
+        $selectedValues = [];
+        foreach ($value as $selectedValueElement) {
+            $selectedValues[] = $this->getOptionValueScalar($selectedValueElement);
         }
 
         // set preselection from TypoScript


### PR DESCRIPTION
The SelectViewHelper in v13.0.0 provided a `multiple` attribute, but handling of multiple selected values was not working. This commit fixes the issue by correctly reading and displaying multiple values.

Resolves:  #663