### PR TITLE
Remove errorneous function call from partial revert

### DIFF
--- a/Classes/Controller/InvitationController.php
+++ b/Classes/Controller/InvitationController.php
@@ -156,8 +156,6 @@ class InvitationController extends AbstractFrontendController
     {
         $user = $this->userRepository->findByUid($user);
 
-        $this->addVariablesForActionConfirmation(true, $user, 'invitationConfirmation');
-
         // User must exist and hash must be valid
         if ($user === null || !HashUtility::validHash($hash, $user)) {
             $this->addFlashMessage(


### PR DESCRIPTION
After #636 was (partially) reverted in f5c60848210f303057b1a2c64777f0fd43ab5ca4, this function call was missed and now causes issues in InvitationController. This PR fixes this oversight.

Fixes #669