### PR TITLE
[BUGFIX] Fix femanager log TCA foreign_table typo

### DIFF
--- a/Configuration/TCA/tx_femanager_domain_model_log.php
+++ b/Configuration/TCA/tx_femanager_domain_model_log.php
@@ -187,7 +187,7 @@ return [
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'foreign_table' => 'fe_user',
+                'foreign_table' => 'fe_users',
                 'default' => 0,
             ]
         ],


### PR DESCRIPTION
- tx_femanager_domain_model_log.user referenced 'fe_user' instead of 'fe_users'
- fixes backend crash when opening femanager log records