### PR TITLE
[BUGFIX] Show correct message on server side validation error

### DIFF
--- a/Classes/Domain/Service/ValidationService.php
+++ b/Classes/Domain/Service/ValidationService.php
@@ -34,7 +34,7 @@ class ValidationService
                 foreach ($errors as $error) {
                     $validationErrors[] = GeneralUtility::makeInstance(
                         FlashMessage::class,
-                        LocalizationUtility::translate('validationErrorUniqueDb', 'femanager', $error->getArguments()),
+                        LocalizationUtility::translate($error['message'], 'femanager', $error->getArguments()),
                         $error->getTitle(),
                         ContextualFeedbackSeverity::ERROR,
                     );


### PR DESCRIPTION
The server side validation always returned the error message of `validationErrorUniqueDb` instead of the actual error message determined by the `ValidationService` if a server side validation error occurs.

This was broken since the introduction of the `ValidationService` in 60e84770 `[BUGFIX] execute serversideValidator user after modifications`