### PR TITLE
[BUGFIX] Fix missing pid on log entries

### DIFF
--- a/Classes/Utility/LogUtility.php
+++ b/Classes/Utility/LogUtility.php
@@ -39,6 +39,7 @@ class LogUtility
 
             if ($user) {
                 $log->setUser($user);
+                $log->setPid($user->getPid());
             }
 
             if (!empty($additionalProperties)) {


### PR DESCRIPTION
This fixes an issue where the pid on a log entry could be 0 instead of the user id.

If the pid is 0, editors that don't have full permissions might be unable to edit users that have such log entries associated with them (although they do have the permissions to edit the user).

This fixes #705  