### PR TITLE
[BUGFIX] Display time for `crdate` of `tx_femanager_domain_model_log` in the backend

### DIFF
--- a/Configuration/TCA/tx_femanager_domain_model_log.php
+++ b/Configuration/TCA/tx_femanager_domain_model_log.php
@@ -57,7 +57,7 @@ return [
                 'tx_femanager_domain_model_log.crdate',
             'config' => [
                 'type' => 'datetime',
-                'format' => 'date',
+                'format' => 'datetime',
                 'readOnly' => true,
                 'default' => time(),
             ],


### PR DESCRIPTION
When editing a `fe_users` record in the backend, the field `crdate` of Log entries only contained the date, no longer the time of creation, despite the label even being "Time" for "tx_femanager_domain_model_log.crdate"

Commit 05a9adad `[TASK] fix tca migration notices, general tca cleanup` overlooked that, Commit 68641710 fixed it for `fe_users` already.