### PR TITLE
[BUGFIX] Invalidate session cookie when deleting account

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -25,6 +25,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Annotation\Validate;
 use TYPO3\CMS\Extbase\Http\ForwardResponse;
+use TYPO3\CMS\Frontend\Authentication\FrontendUserAuthentication;
 
 /**
  * Class EditController
@@ -218,6 +219,8 @@ class EditController extends AbstractFrontendController
         $this->logUtility->log(Log::STATUS_PROFILEDELETE, $user);
         $this->addFlashMessage(LocalizationUtility::translateByState(Log::STATUS_PROFILEDELETE));
         $this->userRepository->remove($user);
+        $this->invalidateSessionCookie();
+
         return $this->redirectByAction('delete', 'redirect', 'edit');
     }
 
@@ -249,5 +252,13 @@ class EditController extends AbstractFrontendController
             'confirmUpdateRequest' => 'edit',
             'delete' => 'edit',
         ];
+    }
+
+    protected function invalidateSessionCookie()
+    {
+        $frontendUser = $this->request->getAttribute('frontend.user');
+        if ($frontendUser instanceof FrontendUserAuthentication) {
+            $frontendUser->logoff();
+        }
     }
 }


### PR DESCRIPTION
The deleteAction did not invalidate the fe_typo_user cookie, which caused subsequent logins with a different account to fail, as the browser sent an invalid session cookie.

I admit this is an edge case.