### PR TITLE
Add Hungarian (hu) translations

### DIFF
--- a/Resources/Private/Language/hu.locallang.xlf
+++ b/Resources/Private/Language/hu.locallang.xlf
@@ -1,0 +1,960 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff version="1.0">
+  <file source-language="en" datatype="plaintext" original="messages" date="2013-04-13T15:49:07Z" product-name="femanager" target-language="hu">
+    <header/>
+    <body>
+<trans-unit id="tx_femanager_domain_model_user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.username" approved="yes">
+				<source>Username</source>
+				<target state="final">Felhasználónév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.password" approved="yes">
+				<source>Password</source>
+				<target state="final">Jelszó</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.password_repeat" approved="yes">
+				<source>Repeat Password</source>
+				<target state="final">Jelszó megismétlése</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.usergroup" approved="yes">
+				<source>Usergroup</source>
+				<target state="final">Felhasználói csoport</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.name" approved="yes">
+				<source>Full Name</source>
+				<target state="final">Teljes név</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.firstName" approved="yes">
+				<source>Firstname</source>
+				<target state="final">Keresztnév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.middleName" approved="yes">
+				<source>Middlename</source>
+				<target state="final">Középső név</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.lastName" approved="yes">
+				<source>Lastname</source>
+				<target state="final">Vezetéknév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.dateOfBirth" approved="yes">
+				<source>Birthdate</source>
+				<target state="final">Születési dátum</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.dateOfBirth.hint" approved="yes">
+				<source>Please type your birthdate as MM/DD/YYYY</source>
+				<target state="final">Kérjük, add meg a születési dátumod MM/DD/YYYY formátumban</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.dateOfBirth.placeholder" approved="yes">
+				<source>MM/DD/YYYY</source>
+				<target state="final">MM/DD/YYYY</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.dateFormat" approved="yes">
+				<source>m/d/Y</source>
+				<target state="final">m/d/Y</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender" approved="yes">
+				<source>Gender</source>
+				<target state="final">Nem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item0" approved="yes">
+				<source>Male</source>
+				<target state="final">Férfi</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item1" approved="yes">
+				<source>Female</source>
+				<target state="final">Nő</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item2" approved="yes">
+				<source>Diverse</source>
+				<target state="final">Egyéb</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.address" approved="yes">
+				<source>Address</source>
+				<target state="final">Cím</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.telephone" approved="yes">
+				<source>Telephone</source>
+				<target state="final">Telefon</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.fax" approved="yes">
+				<source>Fax</source>
+				<target state="final">Fax</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.email" approved="yes">
+				<source>Email</source>
+				<target state="final">E-mail</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.title" approved="yes">
+				<source>Title</source>
+				<target state="final">Titulus</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.zip" approved="yes">
+				<source>ZIP</source>
+				<target state="final">Irányítószám</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.city" approved="yes">
+				<source>City</source>
+				<target state="final">Város</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.country" approved="yes">
+				<source>Country</source>
+				<target state="final">Ország</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.state" approved="yes">
+				<source>State</source>
+				<target state="final">Tartomány</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.www" approved="yes">
+				<source>Website</source>
+				<target state="final">Weboldal</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.company" approved="yes">
+				<source>Company</source>
+				<target state="final">Cég</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.image" approved="yes">
+				<source>Image</source>
+				<target state="final">Kép</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.captcha" approved="yes">
+				<source>Captcha</source>
+				<target state="final">Captcha</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.terms" approved="yes">
+				<source>I accept the terms and conditions</source>
+				<target state="final">Elfogadom az általános szerződési feltételeket</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.termslinktext" approved="yes">
+				<source>Click here for terms and conditions</source>
+				<target state="final">Kattints ide az általános szerződési feltételekért</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.lastlogin" approved="yes">
+				<source>Last login</source>
+				<target state="final">Utolsó bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.inactivesince" approved="yes">
+				<source>Inactive since</source>
+				<target state="final">Inaktív ekkortól</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.crdate" approved="yes">
+				<source>Creation Time</source>
+				<target state="final">Létrehozás ideje</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log" approved="yes">
+				<source>User Log</source>
+				<target state="final">Felhasználói napló</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.title" approved="yes">
+				<source>Title</source>
+				<target state="final">Cím</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.crdate" approved="yes">
+				<source>Time</source>
+				<target state="final">Időpont</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state" approved="yes">
+				<source>State</source>
+				<target state="final">Állapot</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.additional_properties" approved="yes">
+				<source>Additional Properties</source>
+				<target state="final">További tulajdonságok</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.100" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.101" approved="yes">
+				<source>New Registration</source>
+				<target state="final">Új regisztráció</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.102" approved="yes">
+				<source>Registration confirmed by user</source>
+				<target state="final">Regisztráció felhasználó által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.103" approved="yes">
+				<source>Registration confirmed by admin</source>
+				<target state="final">Regisztráció adminisztrátor által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.104" approved="yes">
+				<source>Registration refused by user</source>
+				<target state="final">Regisztráció felhasználó által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.105" approved="yes">
+				<source>Registration refused by admin</source>
+				<target state="final">Regisztráció adminisztrátor által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.106" approved="yes">
+				<source>Profile creation request</source>
+				<target state="final">Profil létrehozására vonatkozó kérelem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.200" approved="yes">
+				<source>Update</source>
+				<target state="final">Frissítés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.201" approved="yes">
+				<source>Profile updated</source>
+				<target state="final">Profil frissítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.202" approved="yes">
+				<source>Profile update confirmed by admin</source>
+				<target state="final">Profil frissítése adminisztrátor által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.203" approved="yes">
+				<source>Profile update refused by admin</source>
+				<target state="final">Profil frissítése adminisztrátor által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.204" approved="yes">
+				<source>Profile update request</source>
+				<target state="final">Profil frissítésére vonatkozó kérelem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.205" approved="yes">
+				<source>Profile update security failure</source>
+				<target state="final">Profil frissítésének biztonsági hibája</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.206" approved="yes">
+				<source>Image deleted</source>
+				<target state="final">Kép törölve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.207" approved="yes">
+				<source>Attempted to spoof profile</source>
+				<target state="final">Kísérlet a profil meghamisítására</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.208" approved="yes">
+				<source>Profile update not authorized</source>
+				<target state="final">Profil frissítése nem engedélyezett</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.300" approved="yes">
+				<source>Delete</source>
+				<target state="final">Törlés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.301" approved="yes">
+				<source>Profile deleted</source>
+				<target state="final">Profil törölve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.400" approved="yes">
+				<source>Invitation</source>
+				<target state="final">Meghívás</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.401" approved="yes">
+				<source>Profile created and user invited</source>
+				<target state="final">Profil létrehozva, a felhasználó meghívva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.402" approved="yes">
+				<source>Profile deleted by user</source>
+				<target state="final">Profil törölve a felhasználó által</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.403" approved="yes">
+				<source>Wrong hash</source>
+				<target state="final">Hibás hash</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.404" approved="yes">
+				<source>You tried to open a restricted page</source>
+				<target state="final">Megpróbáltál megnyitni egy korlátozott oldalt</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.405" approved="yes">
+				<source>Password changed and profile activated</source>
+				<target state="final">Jelszó módosítva és profil aktiválva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.501" approved="yes">
+				<source>Was impersonated by Backend User (login as)</source>
+				<target state="final">Megszemélyesítés a backend-felhasználó által (login as)</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.502" approved="yes">
+				<source>Impersonation was denied for Backend User (login as)</source>
+				<target state="final">Megszemélyesítés megtagadva a backend-felhasználó számára (login as)</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.600" approved="yes">
+				<source>Frontend Login</source>
+				<target state="final">Frontend-bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.601" approved="yes">
+				<source>Successful frontend login</source>
+				<target state="final">Sikeres frontend-bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.602" approved="yes">
+				<source>Failed frontend login</source>
+				<target state="final">Sikertelen frontend-bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="error_no_typoscript" approved="yes">
+				<source>No TypoScript found. Did you already include the static Template?</source>
+				<target state="final">Nem található TypoScript. Már beillesztetted a statikus sablont?</target>
+			</trans-unit>
+<trans-unit id="error_no_typoscript_be" approved="yes">
+				<source>No TypoScript found. Did you already setup module.tx_femanager.settings.configPID in your PageTS?</source>
+				<target state="final">Nem található TypoScript. Már beállítottad a module.tx_femanager.settings.configPID értéket a PageTS-ben?</target>
+			</trans-unit>
+<trans-unit id="error_no_storagepid" approved="yes">
+				<source>No Storage PID was set. Please set the storage PID via TypoScript or in the plugin settings.</source>
+				<target state="final">Nincs beállítva Storage PID. Kérjük, állítsd be a Storage PID-et a TypoScriptben vagy a plugin beállításaiban.</target>
+			</trans-unit>
+<trans-unit id="error_not_authorized" approved="yes">
+				<source>You are not authorized for this action</source>
+				<target state="final">Nincs jogosultságod ehhez a művelethez</target>
+			</trans-unit>
+<trans-unit id="validationError" approved="yes">
+				<source>Error</source>
+				<target state="final">Hiba</target>
+			</trans-unit>
+<trans-unit id="validationErrorRequiredModel" approved="yes">
+				<source>Username and password must be filled</source>
+				<target state="final">Meg kell adni a felhasználónevet és a jelszót</target>
+			</trans-unit>
+<trans-unit id="validationErrorWrongDateFormat" approved="yes">
+				<source>Given date format is wrong</source>
+				<target state="final">A megadott dátumformátum hibás</target>
+			</trans-unit>
+<trans-unit id="validationErrorRequired" approved="yes">
+				<source>Field %s is required</source>
+				<target state="final">A(z) %s mező kitöltése kötelező</target>
+			</trans-unit>
+<trans-unit id="validationErrorEmail" approved="yes">
+				<source>Field %s is not a valid email address</source>
+				<target state="final">A(z) %s mező nem érvényes e-mail cím</target>
+			</trans-unit>
+<trans-unit id="validationErrorMin" approved="yes">
+				<source>Please add more characters to field %s</source>
+				<target state="final">Kérjük, adj hozzá több karaktert a(z) %s mezőhöz</target>
+			</trans-unit>
+<trans-unit id="validationErrorMax" approved="yes">
+				<source>Please add less characters to field %s</source>
+				<target state="final">A(z) %s mezőben kevesebb karaktert adj meg</target>
+			</trans-unit>
+<trans-unit id="validationErrorMinInt" approved="yes">
+				<source>Please respect the minimum value for field %s</source>
+				<target state="final">Kérlek, tartsd be a(z) %s mező minimális értékét</target>
+			</trans-unit>
+<trans-unit id="validationErrorMaxInt" approved="yes">
+				<source>Please respect the maximum value for field %s</source>
+				<target state="final">Kérlek, tartsd be a(z) %s mező maximális értékét</target>
+			</trans-unit>
+<trans-unit id="validationErrorInt" approved="yes">
+				<source>Only numbers are allowed in field %s</source>
+				<target state="final">A(z) %s mezőbe csak számokat írhatsz</target>
+			</trans-unit>
+<trans-unit id="validationErrorLetters" approved="yes">
+				<source>Only letters are allowed in field %s</source>
+				<target state="final">A(z) %s mezőbe csak betűket írhatsz</target>
+			</trans-unit>
+<trans-unit id="validationErrorUniquePage" approved="yes">
+				<source>Value of field %s is already in use</source>
+				<target state="final">A(z) %s mező értéke már használatban van</target>
+			</trans-unit>
+<trans-unit id="validationErrorUniqueDb" approved="yes">
+				<source>Value of field %s is already in use</source>
+				<target state="final">A(z) %s mező értéke már használatban van</target>
+			</trans-unit>
+<trans-unit id="validationErrorMustInclude" approved="yes">
+				<source>Try another value for field %s</source>
+				<target state="final">A(z) %s mezőhöz próbálj más értéket</target>
+			</trans-unit>
+<trans-unit id="validationErrorMustNotInclude" approved="yes">
+				<source>Not allowed signs in field %s</source>
+				<target state="final">A(z) %s mezőben nem megengedett karakterek szerepelnek</target>
+			</trans-unit>
+<trans-unit id="validationErrorInList" approved="yes">
+				<source>This value is not allowed in field %s</source>
+				<target state="final">Ez az érték nem megengedett a(z) %s mezőben</target>
+			</trans-unit>
+<trans-unit id="validationErrorSameAs" approved="yes">
+				<source>Values do not match</source>
+				<target state="final">Az értékek nem egyeznek</target>
+			</trans-unit>
+<trans-unit id="validationErrorPasswordRepeat" approved="yes">
+				<source>Both passwords do not match</source>
+				<target state="final">A két jelszó nem egyezik</target>
+			</trans-unit>
+<trans-unit id="validationErrorDate" approved="yes">
+				<source>Date has the wrong format</source>
+				<target state="final">A dátum formátuma hibás</target>
+			</trans-unit>
+<trans-unit id="validationErrorCaptcha" approved="yes">
+				<source>Wrong Captcha code</source>
+				<target state="final">Hibás captcha kód</target>
+			</trans-unit>
+<trans-unit id="validationErrorGeneral" approved="yes">
+				<source>Field could not be validated</source>
+				<target state="final">A mezőt nem sikerült ellenőrizni</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationSubject" approved="yes">
+				<source>Please confirm a new registration</source>
+				<target state="final">Kérlek, hagyd jóvá az új regisztrációt</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationSalutation" approved="yes">
+				<source>Dear Admin,</source>
+				<target state="final">Kedves Adminisztrátor,</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationUserProperties" approved="yes">
+				<source>User properties:</source>
+				<target state="final">Felhasználói adatok:</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationText1" approved="yes">
+				<source>Please confirm registration of %s by clicking the following link:</source>
+				<target state="final">Kérlek, erősítsd meg a(z) %s regisztrációját a következő linkre kattintva:</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationLinkConfirm" approved="yes">
+				<source>Confirm registration</source>
+				<target state="final">Regisztráció megerősítése</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationText2" approved="yes">
+				<source>If you want to delete the registration, click this link:</source>
+				<target state="final">Ha törölni szeretnéd a regisztrációt, kattints erre a linkre:</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationLinkConfirmRefused" approved="yes">
+				<source>Delete profile</source>
+				<target state="final">Profil törlése</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationText3" approved="yes">
+				<source>If you want to delete the registration, without sending an email to the user, click this link:</source>
+				<target state="final">Ha törölni szeretnéd a regisztrációt anélkül, hogy e-mailt küldenél a felhasználónak, kattints erre a linkre:</target>
+			</trans-unit>
+<trans-unit id="emailCreateAdminConfirmationLinkConfirmRefusedSilent" approved="yes">
+				<source>Silently delete profile</source>
+				<target state="final">Profil csendes törlése</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationSubject" approved="yes">
+				<source>Please confirm your profile creation request</source>
+				<target state="final">Kérlek, erősítsd meg a profil létrehozására vonatkozó kérelmedet</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationSalutation" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationText1" approved="yes">
+				<source>Please confirm your profile registration on our server by clicking the following link:</source>
+				<target state="final">Kérlek, erősítsd meg a profilod regisztrációját a szerverünkön a következő linkre kattintva:</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationLinkConfirm" approved="yes">
+				<source>Confirm profile</source>
+				<target state="final">Profil megerősítése</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationText2" approved="yes">
+				<source>If you don't want to be registered on our system, click this link:</source>
+				<target state="final">Ha nem szeretnél regisztrálva lenni a rendszerünkben, kattints erre a linkre:</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationLinkConfirmRefused" approved="yes">
+				<source>Delete profile</source>
+				<target state="final">Profil törlése</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserConfirmationSignature" approved="yes">
+				<source>Your website team.</source>
+				<target state="final">A weboldal csapata.</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifySubject" approved="yes">
+				<source>Your registration was confirmed</source>
+				<target state="final">A regisztrációdat megerősítettük</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifySalutation" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifyText1" approved="yes">
+				<source>Your profile was confirmed and successfully created.</source>
+				<target state="final">A profilodat megerősítettük, és sikeresen létrehoztuk.</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifySignature" approved="yes">
+				<source>Your website team.</source>
+				<target state="final">A weboldal csapata.</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifyRefusedSubject" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifyRefusedSalutation" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifyRefusedText1" approved="yes">
+				<source>Thank you for your profile request. We're sorry to tell you, that we had to refuse your request.</source>
+				<target state="final">Köszönjük a profil-kérelmedet. Sajnálattal közöljük, hogy el kellett utasítanunk a kérelmedet.</target>
+			</trans-unit>
+<trans-unit id="emailCreateUserNotifyRefusedSignature" approved="yes">
+				<source>Your website team.</source>
+				<target state="final">A weboldal csapata.</target>
+			</trans-unit>
+<trans-unit id="emailCreateNotifySubject" approved="yes">
+				<source>New profile registration</source>
+				<target state="final">Új profilregisztráció</target>
+			</trans-unit>
+<trans-unit id="emailCreateNotifySalutation" approved="yes">
+				<source>Dear Admin,</source>
+				<target state="final">Kedves Adminisztrátor,</target>
+			</trans-unit>
+<trans-unit id="emailCreateNotifyText1" approved="yes">
+				<source>Profile creation - User %s</source>
+				<target state="final">Profil létrehozása – %s felhasználó</target>
+			</trans-unit>
+<trans-unit id="emailCreateNotifyText2" approved="yes">
+				<source>Profile creation - User %s set a new password and profile was enabled</source>
+				<target state="final">Profil létrehozása – %s felhasználó új jelszót állított be, és a profil aktiválva lett</target>
+			</trans-unit>
+<trans-unit id="emailCreateNotifyUserProperties" approved="yes">
+				<source>Profile properties:</source>
+				<target state="final">Profil adatai:</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifySubject" approved="yes">
+				<source>Profile update</source>
+				<target state="final">Profil módosítás</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifySalutation" approved="yes">
+				<source>Dear Admin,</source>
+				<target state="final">Kedves Adminisztrátor,</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifyText1" approved="yes">
+				<source>Profile change by user %s</source>
+				<target state="final">%s felhasználó módosította a profilját</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifyField" approved="yes">
+				<source>Fieldname</source>
+				<target state="final">Mező neve</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifyOld" approved="yes">
+				<source>Old value</source>
+				<target state="final">Régi érték</target>
+			</trans-unit>
+<trans-unit id="emailUpdateNotifyNew" approved="yes">
+				<source>New value</source>
+				<target state="final">Új érték</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestSubject" approved="yes">
+				<source>New profile change request</source>
+				<target state="final">Új profil-módosítási kérelem</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestSalutation" approved="yes">
+				<source>Dear Admin,</source>
+				<target state="final">Kedves Adminisztrátor,</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestText1" approved="yes">
+				<source>Profile change request from %s</source>
+				<target state="final">Profil-módosítási kérelem %s felhasználótól</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestText2" approved="yes">
+				<source>All changes:</source>
+				<target state="final">Minden változás:</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestField" approved="yes">
+				<source>Fieldname</source>
+				<target state="final">Mező neve</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestOld" approved="yes">
+				<source>Old value</source>
+				<target state="final">Régi érték</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestNew" approved="yes">
+				<source>New value</source>
+				<target state="final">Új érték</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestLinkConfirm" approved="yes">
+				<source>Confirm changes</source>
+				<target state="final">Módosítások megerősítése</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestLinkRefuse" approved="yes">
+				<source>Refuse changes and notify user</source>
+				<target state="final">Módosítások elutasítása és a felhasználó értesítése</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestLinkSiltentRefuse" approved="yes">
+				<source>Refuse changes and do not notify user</source>
+				<target state="final">Módosítások elutasítása a felhasználó értesítése nélkül</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestRefusedSubject" approved="yes">
+				<source>Your update request was refused</source>
+				<target state="final">A módosítási kérelmed elutasításra került</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestRefusedSalutation" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestRefusedText1" approved="yes">
+				<source>Thank you for your update request. We're sorry to tell you, that we had to refuse your request.</source>
+				<target state="final">Köszönjük a módosítási kérelmedet. Sajnálattal tudatjuk, hogy kérelmedet el kellett utasítanunk.</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestRefusedText2" approved="yes">
+				<source>Please contact %s for further information.</source>
+				<target state="final">További információkért fordulj a következőhöz: %s.</target>
+			</trans-unit>
+<trans-unit id="emailUpdateRequestRefusedSignature" approved="yes">
+				<source>Your website team.</source>
+				<target state="final">A weboldal csapata.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationSubject" approved="yes">
+				<source>Confirm your profile</source>
+				<target state="final">Erősítsd meg a profilod</target>
+			</trans-unit>
+<trans-unit id="emailInvitationSalutation" approved="yes">
+				<source>Dear</source>
+				<target state="final">Kedves</target>
+			</trans-unit>
+<trans-unit id="emailInvitationText1" approved="yes">
+				<source>Your new profile was just created.</source>
+				<target state="final">Az új profilod éppen most került létrehozásra.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationText2" approved="yes">
+				<source>Please confirm your profile registration on our server by clicking the following link. After that, you can define a password and activate your profile.</source>
+				<target state="final">Kérjük, erősítsd meg profilod regisztrációját a szerverünkön a következő linkre kattintva. Ezt követően megadhatsz egy jelszót, és aktiválhatod a profilod.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationLinkConfirm" approved="yes">
+				<source>Confirm Profile</source>
+				<target state="final">Profil megerősítése</target>
+			</trans-unit>
+<trans-unit id="emailInvitationText3" approved="yes">
+				<source>If you don't want to be registered on our system, click this link.</source>
+				<target state="final">Ha nem szeretnél regisztrálva lenni a rendszerünkben, kattints erre a linkre.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationLinkConfirmRefused" approved="yes">
+				<source>Delete Profile</source>
+				<target state="final">Profil törlése</target>
+			</trans-unit>
+<trans-unit id="emailInvitationSignature" approved="yes">
+				<source>Your website team.</source>
+				<target state="final">A weboldal csapata.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationAdminNotifiyStep1Subject" approved="yes">
+				<source>User was invited</source>
+				<target state="final">A felhasználó meghívásra került</target>
+			</trans-unit>
+<trans-unit id="emailInvitationAdminNotifiySubject" approved="yes">
+				<source>User invitation - Profile finally created</source>
+				<target state="final">Felhasználói meghívás – profil véglegesen létrehozva</target>
+			</trans-unit>
+<trans-unit id="emailInvitationUserRefusedAdminNotifiyStep1Subject" approved="yes">
+				<source>User refused invitation</source>
+				<target state="final">A felhasználó visszautasította a meghívást</target>
+			</trans-unit>
+<trans-unit id="emailInvitationUserRefusedAdminNotifiySalutation" approved="yes">
+				<source>Dear Admin,</source>
+				<target state="final">Kedves Adminisztrátor,</target>
+			</trans-unit>
+<trans-unit id="emailInvitationUserRefusedAdminNotifiyText1" approved="yes">
+				<source>Profile invitation of %s</source>
+				<target state="final">%s profiljának meghívása</target>
+			</trans-unit>
+<trans-unit id="emailInvitationUserRefusedAdminNotifiyText2" approved="yes">
+				<source>Profile invitation - User %s refused to set a new password. The profile was deleted.</source>
+				<target state="final">Profilmeghívás – %s felhasználó megtagadta az új jelszó beállítását. A profil törlésre került.</target>
+			</trans-unit>
+<trans-unit id="emailInvitationUserRefusedAdminNotifiyUserProperties" approved="yes">
+				<source>Profile properties:</source>
+				<target state="final">Profil adatai:</target>
+			</trans-unit>
+<trans-unit id="noRecordsFound" approved="yes">
+				<source>No records found.</source>
+				<target state="final">Nem található rekord.</target>
+			</trans-unit>
+<trans-unit id="noRecordsFoundClearFilter" approved="yes">
+				<source>Clean filter.</source>
+				<target state="final">Szűrő törlése.</target>
+			</trans-unit>
+<trans-unit id="noRecordsFoundGoToPage0" approved="yes">
+				<source>Show all users from all pages (for administrators only).</source>
+				<target state="final">Összes felhasználó mutatása minden oldalról (csak adminisztrátoroknak).</target>
+			</trans-unit>
+<trans-unit id="noRecordFoundShow" approved="yes">
+				<source>No FE_User given or not logged in</source>
+				<target state="final">Nincs megadva FE_User, vagy nincs bejelentkezve</target>
+			</trans-unit>
+<trans-unit id="notLoggedIn" approved="yes">
+				<source>Please log in before</source>
+				<target state="final">Kérjük, előbb jelentkezzen be</target>
+			</trans-unit>
+<trans-unit id="submitNew" approved="yes">
+				<source>Create Profile Now</source>
+				<target state="final">Profil létrehozása</target>
+			</trans-unit>
+<trans-unit id="submitActivate" approved="yes">
+				<source>Activate Profile</source>
+				<target state="final">Profil aktiválása</target>
+			</trans-unit>
+<trans-unit id="submitResend" approved="yes">
+				<source>Resend now</source>
+				<target state="final">Újraküldés</target>
+			</trans-unit>
+<trans-unit id="passwordRepeat" approved="yes">
+				<source>Repeat Password</source>
+				<target state="final">Jelszó megismétlése</target>
+			</trans-unit>
+<trans-unit id="titleCreateProfile" approved="yes">
+				<source>Create a new user-profile</source>
+				<target state="final">Új felhasználói profil létrehozása</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationMailTitle" approved="yes">
+				<source>Resend confirmation mail</source>
+				<target state="final">Megerősítő e-mail újraküldése</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationMailFieldsetLegend" approved="yes">
+				<source>Please enter your email address</source>
+				<target state="final">Kérjük, adja meg az e-mail címét</target>
+			</trans-unit>
+<trans-unit id="submitEdit" approved="yes">
+				<source>Update Profile</source>
+				<target state="final">Profil frissítése</target>
+			</trans-unit>
+<trans-unit id="create" approved="yes">
+				<source>Profile successfully created</source>
+				<target state="final">A profil sikeresen létrehozva</target>
+			</trans-unit>
+<trans-unit id="createAndInvited" approved="yes">
+				<source>Profile successfully created and user informed</source>
+				<target state="final">A profil sikeresen létrehozva és a felhasználó értesítve</target>
+			</trans-unit>
+<trans-unit id="createAndInvitedFinished" approved="yes">
+				<source>Profile successfully changed and enabled</source>
+				<target state="final">A profil sikeresen módosítva és aktiválva</target>
+			</trans-unit>
+<trans-unit id="createRequestWaitingForUserConfirm" approved="yes">
+				<source>Thank you for your request. Please check your mail account to confirm the profile.</source>
+				<target state="final">Köszönjük a kérését. Kérjük, ellenőrizze az e-mail-fiókját a profil megerősítéséhez.</target>
+			</trans-unit>
+<trans-unit id="createRequestWaitingForAdminConfirm" approved="yes">
+				<source>Thank you for your registration. Your profile will be available as soon as the admin confirms your request.</source>
+				<target state="final">Köszönjük a regisztrációt. Profilja akkor lesz elérhető, amint az adminisztrátor megerősíti a kérését.</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationMailSend" approved="yes">
+				<source>An email was sent to your account. Please check your inbox.</source>
+				<target state="final">E-mailt küldtünk a fiókjára. Kérjük, ellenőrizze a bejövő leveleit.</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationMailFail" approved="yes">
+				<source>We received no valid mail.</source>
+				<target state="final">Nem kaptunk érvényes e-mailt.</target>
+			</trans-unit>
+<trans-unit id="ratelimiter_too_many_attempts" approved="yes">
+				<source>Too many attempts from this IP address. Try again later.</source>
+				<target state="final">Túl sok próbálkozás erről az IP-címről. Próbálja újra később.</target>
+			</trans-unit>
+<trans-unit id="createFailedProfile" approved="yes">
+				<source>Profile creation failed</source>
+				<target state="final">A profil létrehozása sikertelen</target>
+			</trans-unit>
+<trans-unit id="userAlreadyConfirmed" approved="yes">
+				<source>Profile is already confirmed</source>
+				<target state="final">A profil már meg van erősítve</target>
+			</trans-unit>
+<trans-unit id="missingUserInDatabase" approved="yes">
+				<source>No Profile found in database. Maybe it was deleted before.</source>
+				<target state="final">A profil nem található az adatbázisban. Lehet, hogy korábban törölték.</target>
+			</trans-unit>
+<trans-unit id="createProfileDeleted" approved="yes">
+				<source>Profile successfully deleted</source>
+				<target state="final">A profil sikeresen törölve</target>
+			</trans-unit>
+<trans-unit id="titleUpdateProfile" approved="yes">
+				<source>Update your user-profile</source>
+				<target state="final">Felhasználói profiljának frissítése</target>
+			</trans-unit>
+<trans-unit id="confirmUserConfirmation" approved="yes">
+				<source>Please confirm the creation of your account.</source>
+				<target state="final">Kérjük, erősítse meg a fiókja létrehozását.</target>
+			</trans-unit>
+<trans-unit id="confirmUserConfirmationRefused" approved="yes">
+				<source>Please confirm the deletion of your account.</source>
+				<target state="final">Kérjük, erősítse meg a fiókja törlését.</target>
+			</trans-unit>
+<trans-unit id="confirmAdminConfirmation" approved="yes">
+				<source>Please confirm the creation of this account.</source>
+				<target state="final">Kérjük, erősítse meg a fiók létrehozását.</target>
+			</trans-unit>
+<trans-unit id="confirmAdminConfirmationRefused" approved="yes">
+				<source>Please confirm the deletion of this account.</source>
+				<target state="final">Kérjük, erősítse meg a fiók törlését.</target>
+			</trans-unit>
+<trans-unit id="confirmAdminConfirmationRefusedSilent" approved="yes">
+				<source>Please confirm the silent deletion of this account.</source>
+				<target state="final">Kérjük, erősítse meg a fiók néma törlését.</target>
+			</trans-unit>
+<trans-unit id="update" approved="yes">
+				<source>Profile successfully changed</source>
+				<target state="final">A profil sikeresen módosítva</target>
+			</trans-unit>
+<trans-unit id="noChanges" approved="yes">
+				<source>No changes detected, nothing to update</source>
+				<target state="final">Nem történt változás, nincs mit frissíteni</target>
+			</trans-unit>
+<trans-unit id="updateRequest" approved="yes">
+				<source>Your change request was transmitted to the administrator. After a confirmation, your profile will be up-to-date.</source>
+				<target state="final">A változtatási kérelme továbbításra került az adminisztrátorhoz. A megerősítés után a profilja naprakész lesz.</target>
+			</trans-unit>
+<trans-unit id="login" approved="yes">
+				<source>You're successfully logged in now</source>
+				<target state="final">Sikeresen bejelentkezett</target>
+			</trans-unit>
+<trans-unit id="deleteProfile" approved="yes">
+				<source>Delete Profile</source>
+				<target state="final">Profil törlése</target>
+			</trans-unit>
+<trans-unit id="updateProfile" approved="yes">
+				<source>Profile successfully updated</source>
+				<target state="final">A profil sikeresen frissítve</target>
+			</trans-unit>
+<trans-unit id="updateFailedProfile" approved="yes">
+				<source>Profile update failed</source>
+				<target state="final">A profil frissítése sikertelen</target>
+			</trans-unit>
+<trans-unit id="field_image_fineuploader" approved="yes">
+				<source>Please enable fineUploader plugin</source>
+				<target state="final">Kérjük, engedélyezze a fineUploader bővítményt</target>
+			</trans-unit>
+<trans-unit id="field_image_drag" approved="yes">
+				<source>Drag file</source>
+				<target state="final">Húzza ide a fájlt</target>
+			</trans-unit>
+<trans-unit id="field_image_drag_processing">
+				<source>Drag in progress ...</source>
+				<target state="final" approved="yes">Húzás folyamatban ...</target>
+			</trans-unit>
+<trans-unit id="field_image_upload">
+				<source>Upload</source>
+				<target state="final" approved="yes">Feltöltés</target>
+			</trans-unit>
+<trans-unit id="empty">
+				<source>empty</source>
+				<target state="final" approved="yes">üres</target>
+			</trans-unit>
+<trans-unit id="pleaseChoose">
+				<source>Please choose ...</source>
+				<target state="final" approved="yes">Kérlek, válassz ...</target>
+			</trans-unit>
+<trans-unit id="pleaseChooseCountry">
+				<source>Please choose a country ...</source>
+				<target state="final" approved="yes">Kérlek, válassz országot ...</target>
+			</trans-unit>
+<trans-unit id="FilterLabel">
+				<source>Search</source>
+				<target state="final" approved="yes">Keresés</target>
+			</trans-unit>
+<trans-unit id="FilterPlaceholder">
+				<source>Search ...</source>
+				<target state="final" approved="yes">Keresés ...</target>
+			</trans-unit>
+<trans-unit id="FilterSubmit">
+				<source>Filter now</source>
+				<target state="final" approved="yes">Szűrés most</target>
+			</trans-unit>
+<trans-unit id="UserDeleteConfirmation">
+				<source>Are you sure to delete your profile?</source>
+				<target state="final" approved="yes">Biztosan törlöd a profilodat?</target>
+			</trans-unit>
+<trans-unit id="titleInvitationProfile">
+				<source>Invite a new user</source>
+				<target state="final" approved="yes">Új felhasználó meghívása</target>
+			</trans-unit>
+<trans-unit id="titleInvitationSetPassword">
+				<source>Please set a new password</source>
+				<target state="final" approved="yes">Kérlek, állíts be új jelszót</target>
+			</trans-unit>
+<trans-unit id="BackendListUserDelete">
+				<source>Delete</source>
+				<target state="final" approved="yes">Törlés</target>
+			</trans-unit>
+<trans-unit id="BackendListUserDeleteConfirmation">
+				<source>Are you sure to delete this User?</source>
+				<target state="final" approved="yes">Biztosan törlöd ezt a felhasználót?</target>
+			</trans-unit>
+<trans-unit id="BackendListUserEdit">
+				<source>Edit</source>
+				<target state="final" approved="yes">Szerkesztés</target>
+			</trans-unit>
+<trans-unit id="BackendListUserLogout">
+				<source>Logout</source>
+				<target state="final" approved="yes">Kijelentkezés</target>
+			</trans-unit>
+<trans-unit id="BackendListUserStatusOffline" approved="yes">
+				<source>Offline</source>
+				<target state="final">Offline</target>
+			</trans-unit>
+<trans-unit id="BackendListUserStatusOnline" approved="yes">
+				<source>Online</source>
+				<target state="final">Online</target>
+			</trans-unit>
+<trans-unit id="BackendListUserVisibilityHide">
+				<source>Disable</source>
+				<target state="final" approved="yes">Letiltás</target>
+			</trans-unit>
+<trans-unit id="BackendListUserVisibilityHidden">
+				<source>Hidden</source>
+				<target state="final" approved="yes">Rejtett</target>
+			</trans-unit>
+<trans-unit id="BackendListUserVisibilityUnhide">
+				<source>Enable</source>
+				<target state="final" approved="yes">Engedélyezés</target>
+			</trans-unit>
+<trans-unit id="BackendListFilterLabel">
+				<source>Search</source>
+				<target state="final" approved="yes">Keresés</target>
+			</trans-unit>
+<trans-unit id="BackendListLoginAs">
+				<source>Login as</source>
+				<target state="final" approved="yes">Bejelentkezés mint</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationNoteTitle">
+				<source>Possible action:</source>
+				<target state="final" approved="yes">Lehetséges művelet:</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationNoteText">
+				<source>%s approval(s) available</source>
+				<target state="final" approved="yes">%s jóváhagyás érhető el</target>
+			</trans-unit>
+<trans-unit id="AdminBackendConfirmationNoteText">
+				<source>%s user(s) need to be confirmed by admin</source>
+				<target state="final" approved="yes">%s felhasználó vár adminisztrátori jóváhagyásra</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationColumnAction">
+				<source>Actions</source>
+				<target state="final" approved="yes">Műveletek</target>
+			</trans-unit>
+<trans-unit id="BackendMissingConfigPID">
+				<source>The config PID is missing!</source>
+				<target state="final" approved="yes">A konfigurációs PID hiányzik!</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationColumnUid">
+				<source>UID</source>
+				<target state="final" approved="yes">UID</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationFlashMessageLogout">
+				<source>%s was successfully logged out</source>
+				<target state="final" approved="yes">%s sikeresen ki lett jelentkeztetve</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationFlashMessageConfirmed">
+				<source>%s was successfully approved</source>
+				<target state="final" approved="yes">%s sikeresen jóvá lett hagyva</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationFlashMessageFailed">
+				<source>The user confirmation failed, please check your system log or check your config</source>
+				<target state="final" approved="yes">A felhasználó jóváhagyása nem sikerült, ellenőrizd a rendszernaplót vagy a konfigurációt</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationFlashMessageRefused">
+				<source>%s was refused</source>
+				<target state="final" approved="yes">%s el lett utasítva</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationResendUserConfirmationRequest">
+				<source>resend user confirmation e-mail</source>
+				<target state="final" approved="yes">felhasználói jóváhagyó e-mail újraküldése</target>
+			</trans-unit>
+<trans-unit id="BackendConfirmationFlashMessageReSend">
+				<source>%s confirmation mail was resent</source>
+				<target state="final" approved="yes">%s jóváhagyó e-mailje újra ki lett küldve</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationDialogueMessage">
+				<source>Your userprofile is not confirmed yet.</source>
+				<target state="final" approved="yes">A felhasználói profilod még nincs megerősítve.</target>
+			</trans-unit>
+<trans-unit id="resendConfirmationDialogueLink">
+				<source>Resend confirmation email?</source>
+				<target state="final" approved="yes">Megerősítő e-mail újraküldése?</target>
+			</trans-unit>
+<trans-unit id="createStatus">
+				<source>User registration</source>
+				<target state="final" approved="yes">Felhasználói regisztráció</target>
+			</trans-unit>
+<trans-unit id="js.loading_states">
+				<source>Loading states ...</source>
+				<target state="final" approved="yes">Állapotok betöltése ...</target>
+			</trans-unit>
+  </body>
+  </file>
+</xliff>

--- a/Resources/Private/Language/hu.locallang_csh_fe_users.xlf
+++ b/Resources/Private/Language/hu.locallang_csh_fe_users.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff version="1.0">
+  <file source-language="en" datatype="plaintext" original="messages" date="2013-04-13T15:49:07Z" product-name="femanager" target-language="hu">
+    <header/>
+    <body>
+<trans-unit id="username.description" approved="yes">
+				<source>username</source>
+				<target state="final">felhasználónév</target>
+			</trans-unit>
+  </body>
+  </file>
+</xliff>

--- a/Resources/Private/Language/hu.locallang_db.xlf
+++ b/Resources/Private/Language/hu.locallang_db.xlf
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff version="1.0">
+  <file source-language="en" datatype="plaintext" original="messages" date="2013-04-13T15:49:07Z" product-name="femanager" target-language="hu">
+    <header/>
+    <body>
+<trans-unit id="tx_femanager_domain_model_user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.username" approved="yes">
+				<source>Username</source>
+				<target state="final">Felhasználónév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.password" approved="yes">
+				<source>Password</source>
+				<target state="final">Jelszó</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.usergroup" approved="yes">
+				<source>Usergroup</source>
+				<target state="final">Felhasználócsoport</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.name" approved="yes">
+				<source>Name</source>
+				<target state="final">Név</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.firstName" approved="yes">
+				<source>Firstname</source>
+				<target state="final">Keresztnév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.middleName" approved="yes">
+				<source>Middlename</source>
+				<target state="final">Középső név</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.lastName" approved="yes">
+				<source>Lastname</source>
+				<target state="final">Vezetéknév</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.dateOfBirth" approved="yes">
+				<source>Birthdate</source>
+				<target state="final">Születési dátum</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender" approved="yes">
+				<source>Gender</source>
+				<target state="final">Nem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item0" approved="yes">
+				<source>male</source>
+				<target state="final">férfi</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item1" approved="yes">
+				<source>female</source>
+				<target state="final">nő</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.gender.item2" approved="yes">
+				<source>diverse</source>
+				<target state="final">diverz</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.address" approved="yes">
+				<source>Address</source>
+				<target state="final">Cím</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.telephone" approved="yes">
+				<source>Telephone</source>
+				<target state="final">Telefonszám</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.fax" approved="yes">
+				<source>Fax</source>
+				<target state="final">Fax</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.email" approved="yes">
+				<source>Email</source>
+				<target state="final">E-mail</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.title" approved="yes">
+				<source>Title</source>
+				<target state="final">Megszólítás</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.zip" approved="yes">
+				<source>ZIP</source>
+				<target state="final">Irányítószám</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.city" approved="yes">
+				<source>City</source>
+				<target state="final">Város</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.country" approved="yes">
+				<source>Country</source>
+				<target state="final">Ország</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.state" approved="yes">
+				<source>State</source>
+				<target state="final">Megye</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.www" approved="yes">
+				<source>Website</source>
+				<target state="final">Weboldal</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.company" approved="yes">
+				<source>Company</source>
+				<target state="final">Cég</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.image" approved="yes">
+				<source>Image</source>
+				<target state="final">Kép</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.lastlogin" approved="yes">
+				<source>Last login</source>
+				<target state="final">Utolsó bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.captcha" approved="yes">
+				<source>Captcha</source>
+				<target state="final">Captcha</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.state" approved="yes">
+				<source>State</source>
+				<target state="final">Megye</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_user.terms" approved="yes">
+				<source>Terms and conditions</source>
+				<target state="final">ÁSZF</target>
+			</trans-unit>
+<trans-unit id="fe_users.crdate" approved="yes">
+				<source>Creation Time</source>
+				<target state="final">Létrehozás ideje</target>
+			</trans-unit>
+<trans-unit id="fe_users.tstamp" approved="yes">
+				<source>Last profile change at</source>
+				<target state="final">Utolsó profilváltoztatás ideje</target>
+			</trans-unit>
+<trans-unit id="fe_users.registrationconfirmedbyuser" approved="yes">
+				<source>Registration confirmed by user</source>
+				<target state="final">Regisztráció felhasználó által megerősítve</target>
+			</trans-unit>
+<trans-unit id="fe_users.registrationconfirmedbyadmin" approved="yes">
+				<source>Registration confirmed by admin</source>
+				<target state="final">Regisztráció adminisztrátor által megerősítve</target>
+			</trans-unit>
+<trans-unit id="fe_users.tab" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="fe_users.log" approved="yes">
+				<source>FE_user Log</source>
+				<target state="final">FE felhasználó napló</target>
+			</trans-unit>
+<trans-unit id="fe_users.terms" approved="yes">
+				<source>User accepted terms and conditions</source>
+				<target state="final">A felhasználó elfogadta az ÁSZF-et</target>
+			</trans-unit>
+<trans-unit id="fe_users.terms_version" approved="yes">
+				<source>Accepted version of terms and conditions</source>
+				<target state="final">Elfogadott ÁSZF-verzió</target>
+			</trans-unit>
+<trans-unit id="fe_users.terms_date_of_acceptance" approved="yes">
+				<source>Accepted datetime of terms and conditions</source>
+				<target state="final">ÁSZF elfogadásának időpontja</target>
+			</trans-unit>
+<trans-unit id="fe_users.changerequest" approved="yes">
+				<source>Change Request</source>
+				<target state="final">Módosítási kérelem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log" approved="yes">
+				<source>User Log</source>
+				<target state="final">Felhasználói napló</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.title" approved="yes">
+				<source>Title</source>
+				<target state="final">Cím</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.crdate" approved="yes">
+				<source>Time</source>
+				<target state="final">Időpont</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state" approved="yes">
+				<source>State</source>
+				<target state="final">Állapot</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.additional_properties" approved="yes">
+				<source>Additional Properties</source>
+				<target state="final">További tulajdonságok</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.100" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.101" approved="yes">
+				<source>New Registration</source>
+				<target state="final">Új regisztráció</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.102" approved="yes">
+				<source>Registration confirmed by user</source>
+				<target state="final">Regisztráció felhasználó által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.103" approved="yes">
+				<source>Registration confirmed by admin</source>
+				<target state="final">Regisztráció adminisztrátor által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.104" approved="yes">
+				<source>Registration refused by user</source>
+				<target state="final">Regisztráció felhasználó által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.105" approved="yes">
+				<source>Registration refused by admin</source>
+				<target state="final">Regisztráció adminisztrátor által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.106" approved="yes">
+				<source>Profile creation request</source>
+				<target state="final">Profillétrehozási kérelem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.200" approved="yes">
+				<source>Update</source>
+				<target state="final">Frissítés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.201" approved="yes">
+				<source>Profile updated</source>
+				<target state="final">Profil frissítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.202" approved="yes">
+				<source>Profile update confirmed by admin</source>
+				<target state="final">Profilfrissítés adminisztrátor által megerősítve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.203" approved="yes">
+				<source>Profile update refused by admin</source>
+				<target state="final">Profilfrissítés adminisztrátor által elutasítva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.204" approved="yes">
+				<source>Profile update request</source>
+				<target state="final">Profilfrissítési kérelem</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.205" approved="yes">
+				<source>Profile update security failure</source>
+				<target state="final">Profilfrissítési biztonsági hiba</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.206" approved="yes">
+				<source>Image deleted</source>
+				<target state="final">Kép törölve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.207" approved="yes">
+				<source>Attempted to spoof profile</source>
+				<target state="final">Profilhamisítási kísérlet</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.208" approved="yes">
+				<source>Profile update not authorized</source>
+				<target state="final">Profilfrissítés nem engedélyezett</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.300" approved="yes">
+				<source>Delete</source>
+				<target state="final">Törlés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.301" approved="yes">
+				<source>Profile deleted</source>
+				<target state="final">Profil törölve</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.400" approved="yes">
+				<source>Invitation</source>
+				<target state="final">Meghívás</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.401" approved="yes">
+				<source>Profile created and User invited</source>
+				<target state="final">Profil létrehozva, a felhasználó meghívva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.402" approved="yes">
+				<source>Profile deleted from User</source>
+				<target state="final">A profil törölve a felhasználótól</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.403" approved="yes">
+				<source>Wrong Hash</source>
+				<target state="final">Hibás hash</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.404" approved="yes">
+				<source>You tried to open a restricted page</source>
+				<target state="final">Korlátozott oldalt próbált megnyitni</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.405" approved="yes">
+				<source>Password changed and Profile activated</source>
+				<target state="final">Jelszó módosítva és profil aktiválva</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.500" approved="yes">
+				<source>Backend impersonation</source>
+				<target state="final">Backend megszemélyesítés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.501" approved="yes">
+				<source>Was impersonated by Backend Admin (login as)</source>
+				<target state="final">A backend admin megszemélyesítette (bejelentkezés másként)</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.502" approved="yes">
+				<source>Impersonation was denied for Backend User (login as)</source>
+				<target state="final">A megszemélyesítés megtagadva a backend felhasználótól (bejelentkezés másként)</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.600" approved="yes">
+				<source>Frontend Login</source>
+				<target state="final">Frontend bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.601" approved="yes">
+				<source>Successful frontend login</source>
+				<target state="final">Sikeres frontend bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.state.602" approved="yes">
+				<source>Failed frontend login</source>
+				<target state="final">Sikertelen frontend bejelentkezés</target>
+			</trans-unit>
+<trans-unit id="all" approved="yes">
+				<source>All</source>
+				<target state="final">Összes</target>
+			</trans-unit>
+<trans-unit id="tx_femanager_domain_model_log.user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="flexform.main.title" approved="yes">
+				<source>Main Settings</source>
+				<target state="final">Fő beállítások</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view" approved="yes">
+				<source>Choose View</source>
+				<target state="final">Nézet kiválasztása</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.0" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.1" approved="yes">
+				<source>Edit</source>
+				<target state="final">Szerkesztés</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.2" approved="yes">
+				<source>List</source>
+				<target state="final">Lista</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.3" approved="yes">
+				<source>Detail</source>
+				<target state="final">Részletek</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.4" approved="yes">
+				<source>Invitation</source>
+				<target state="final">Meghívás</target>
+			</trans-unit>
+<trans-unit id="flexform.main.view.5" approved="yes">
+				<source>Resend confirmation mail</source>
+				<target state="final">Megerősítő levél újraküldése</target>
+			</trans-unit>
+<trans-unit id="flexform.new.title" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="flexform.new.fields" approved="yes">
+				<source>Select Fields for New-Form (empty = all fields)</source>
+				<target state="final">Mezők kiválasztása az új űrlaphoz (üres = minden mező)</target>
+			</trans-unit>
+<trans-unit id="flexform.new.overrideUserGroup" approved="yes">
+				<source>Select Usergroups for new Users</source>
+				<target state="final">Felhasználócsoportok kiválasztása az új felhasználóknak</target>
+			</trans-unit>
+<trans-unit id="flexform.new.confirmByUser" approved="yes">
+				<source>Registration must be confirmed from sender</source>
+				<target state="final">A regisztrációt a feladónak meg kell erősítenie</target>
+			</trans-unit>
+<trans-unit id="flexform.new.showTermsAndConditions" approved="yes">
+				<source>User must accept terms and conditions</source>
+				<target state="final">A felhasználónak el kell fogadnia az általános szerződési feltételeket</target>
+			</trans-unit>
+<trans-unit id="flexform.new.confirmByAdmin" approved="yes">
+				<source>Registration must be confirmed from an admin (add one or more emails)</source>
+				<target state="final">A regisztrációt egy adminnak meg kell erősítenie (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.new.notifyAdmin" approved="yes">
+				<source>Notify admin on registration (add one or more emails)</source>
+				<target state="final">Admin értesítése regisztrációkor (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.edit.title" approved="yes">
+				<source>Edit</source>
+				<target state="final">Szerkesztés</target>
+			</trans-unit>
+<trans-unit id="flexform.edit.fields" approved="yes">
+				<source>Select Fields for Edit-Form (empty = all fields)</source>
+				<target state="final">Mezők kiválasztása a szerkesztő űrlaphoz (üres = minden mező)</target>
+			</trans-unit>
+<trans-unit id="flexform.edit.showDeleteLink" approved="yes">
+				<source>Show Delete Button in Edit Form</source>
+				<target state="final">Törlés gomb megjelenítése a szerkesztő űrlapon</target>
+			</trans-unit>
+<trans-unit id="flexform.edit.confirmByAdmin" approved="yes">
+				<source>Profile update must be confirmed from an admin (add one or more emails)</source>
+				<target state="final">A profil frissítését egy adminnak meg kell erősítenie (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.edit.notifyAdmin" approved="yes">
+				<source>Notify admin on Profile update (add one or more emails)</source>
+				<target state="final">Admin értesítése a profil frissítésekor (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.list.title" approved="yes">
+				<source>Listview</source>
+				<target state="final">Listanézet</target>
+			</trans-unit>
+<trans-unit id="flexform.list.filter" approved="yes">
+				<source>Show Searchfield</source>
+				<target state="final">Keresőmező megjelenítése</target>
+			</trans-unit>
+<trans-unit id="flexform.list.limit" approved="yes">
+				<source>Limit</source>
+				<target state="final">Korlát</target>
+			</trans-unit>
+<trans-unit id="flexform.list.orderby" approved="yes">
+				<source>Order by</source>
+				<target state="final">Rendezés alapján</target>
+			</trans-unit>
+<trans-unit id="flexform.list.orderby.0" approved="yes">
+				<source>Lastname</source>
+				<target state="final">Vezetéknév</target>
+			</trans-unit>
+<trans-unit id="flexform.list.orderby.1" approved="yes">
+				<source>Firstname</source>
+				<target state="final">Keresztnév</target>
+			</trans-unit>
+<trans-unit id="flexform.list.orderby.2" approved="yes">
+				<source>Company</source>
+				<target state="final">Cég</target>
+			</trans-unit>
+<trans-unit id="flexform.list.orderby.3" approved="yes">
+				<source>Username</source>
+				<target state="final">Felhasználónév</target>
+			</trans-unit>
+<trans-unit id="flexform.list.sorting" approved="yes">
+				<source>Sorting</source>
+				<target state="final">Rendezés sorrendje</target>
+			</trans-unit>
+<trans-unit id="flexform.list.sorting.0" approved="yes">
+				<source>Ascending</source>
+				<target state="final">Növekvő</target>
+			</trans-unit>
+<trans-unit id="flexform.list.sorting.1" approved="yes">
+				<source>Descending</source>
+				<target state="final">Csökkenő</target>
+			</trans-unit>
+<trans-unit id="flexform.list.usergroup" approved="yes">
+				<source>Show from usergroup (empty = show all)</source>
+				<target state="final">Megjelenítés felhasználócsoport alapján (üres = minden megjelenítése)</target>
+			</trans-unit>
+<trans-unit id="flexform.show.title" approved="yes">
+				<source>Detailview</source>
+				<target state="final">Részletnézet</target>
+			</trans-unit>
+<trans-unit id="flexform.show.user" approved="yes">
+				<source>User to show</source>
+				<target state="final">Megjelenítendő felhasználó</target>
+			</trans-unit>
+<trans-unit id="flexform.show.user.1" approved="yes">
+				<source>[Logged in FE User]</source>
+				<target state="final">[Bejelentkezett FE felhasználó]</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.title" approved="yes">
+				<source>Invitation</source>
+				<target state="final">Meghívás</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.allowedUserGroups" approved="yes">
+				<source>Restrict "Add Invitation" to one or more Usergroups (empty = No Restriction)</source>
+				<target state="final">A "Meghívás hozzáadása" korlátozása egy vagy több felhasználócsoportra (üres = nincs korlátozás)</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.fields" approved="yes">
+				<source>Select Fields for invitation-Form (empty = all fields)</source>
+				<target state="final">Mezők kiválasztása a meghívó űrlaphoz (üres = minden mező)</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.overrideUserGroup" approved="yes">
+				<source>Select Usergroups for new Users</source>
+				<target state="final">Felhasználócsoportok kiválasztása az új felhasználóknak</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.confirmByAdmin" approved="yes">
+				<source>Registration must be confirmed from an admin (add one or more emails)</source>
+				<target state="final">A regisztrációt egy adminnak meg kell erősítenie (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.notifyAdminStep1" approved="yes">
+				<source>Notify admin on step 1 (add one or more emails)</source>
+				<target state="final">Admin értesítése az 1. lépésnél (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.invitation.notifyAdmin" approved="yes">
+				<source>Notify admin if user sets a password (add one or more emails)</source>
+				<target state="final">Admin értesítése, ha a felhasználó jelszót állít be (egy vagy több e-mail cím megadása)</target>
+			</trans-unit>
+<trans-unit id="flexform.misc.title" approved="yes">
+				<source>Additional Settings</source>
+				<target state="final">További beállítások</target>
+			</trans-unit>
+<trans-unit id="flexform.misc.termsUrl" approved="yes">
+				<source>Page with terms and conditions</source>
+				<target state="final">Általános szerződési feltételeket tartalmazó oldal</target>
+			</trans-unit>
+<trans-unit id="pleaseChoose" approved="yes">
+				<source>Please choose...</source>
+				<target state="final">Kérlek, válassz...</target>
+			</trans-unit>
+<trans-unit id="pleaseChooseCountry" approved="yes">
+				<source>Please choose a country...</source>
+				<target state="final">Kérlek, válassz országot...</target>
+			</trans-unit>
+<trans-unit id="noZonesForThisCountry" approved="yes">
+				<source>No zones available for the chosen country</source>
+				<target state="final">Nincs elérhető régió a kiválasztott országhoz</target>
+			</trans-unit>
+<trans-unit id="filter.filter" approved="yes">
+				<source>Filter</source>
+				<target state="final">Szűrő</target>
+			</trans-unit>
+<trans-unit id="filter.reset" approved="yes">
+				<source>Reset</source>
+				<target state="final">Visszaállítás</target>
+			</trans-unit>
+<trans-unit id="filter.user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="filter.state" approved="yes">
+				<source>State</source>
+				<target state="final">Állapot</target>
+			</trans-unit>
+<trans-unit id="filter.from" approved="yes">
+				<source>From</source>
+				<target state="final">Tól</target>
+			</trans-unit>
+<trans-unit id="filter.to" approved="yes">
+				<source>To</source>
+				<target state="final">Ig</target>
+			</trans-unit>
+<trans-unit id="log.headline.time" approved="yes">
+				<source>Time</source>
+				<target state="final">Idő</target>
+			</trans-unit>
+<trans-unit id="log.headline.state" approved="yes">
+				<source>State</source>
+				<target state="final">Állapot</target>
+			</trans-unit>
+<trans-unit id="log.headline.user" approved="yes">
+				<source>User</source>
+				<target state="final">Felhasználó</target>
+			</trans-unit>
+<trans-unit id="log.headline.details" approved="yes">
+				<source>Details</source>
+				<target state="final">Részletek</target>
+			</trans-unit>
+  </body>
+  </file>
+</xliff>

--- a/Resources/Private/Language/hu.locallang_mod.xlf
+++ b/Resources/Private/Language/hu.locallang_mod.xlf
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xliff version="1.0">
+  <file source-language="en" datatype="plaintext" original="messages" date="2013-04-13T15:49:07Z" product-name="femanager" target-language="hu">
+    <header/>
+    <body>
+<trans-unit id="mlang_tabs_tab" approved="yes">
+				<source>Frontend Users</source>
+				<target state="final">Frontend felhasználók</target>
+			</trans-unit>
+<trans-unit id="mlang_labels_tabdescr" approved="yes">
+				<source>FE Manager allows you to see a list of Frontend Users and filter them. Show Users from a usergroup or from a searchword or simply show users which are online</source>
+				<target state="final">A FE Manager segítségével listázhatja és szűrheti a frontend felhasználókat. Megjelenítheti a felhasználókat felhasználói csoport, keresőszó alapján, vagy egyszerűen az online lévő felhasználókat.</target>
+			</trans-unit>
+<trans-unit id="mlang_labels_tablabel" approved="yes">
+				<source>FE Manager</source>
+				<target state="final">FE Manager</target>
+			</trans-unit>
+<trans-unit id="pluginWizardTitle" approved="yes">
+				<source>Femanager</source>
+				<target state="final">Femanager</target>
+			</trans-unit>
+<trans-unit id="femanager_registration.title" approved="yes">
+				<source>Registration</source>
+				<target state="final">Regisztráció</target>
+			</trans-unit>
+<trans-unit id="femanager_registration.description" approved="yes">
+				<source>Description of Registration</source>
+				<target state="final">A Regisztráció leírása</target>
+			</trans-unit>
+<trans-unit id="femanager_edit.title" approved="yes">
+				<source>Edit</source>
+				<target state="final">Szerkesztés</target>
+			</trans-unit>
+<trans-unit id="femanager_edit.description" approved="yes">
+				<source>Description of Edit</source>
+				<target state="final">A Szerkesztés leírása</target>
+			</trans-unit>
+<trans-unit id="femanager_list.title" approved="yes">
+				<source>List</source>
+				<target state="final">Lista</target>
+			</trans-unit>
+<trans-unit id="femanager_list.description" approved="yes">
+				<source>Description of List</source>
+				<target state="final">A Lista leírása</target>
+			</trans-unit>
+<trans-unit id="femanager_detail.title" approved="yes">
+				<source>Detail</source>
+				<target state="final">Részletek</target>
+			</trans-unit>
+<trans-unit id="femanager_detail.description" approved="yes">
+				<source>Description of Detail</source>
+				<target state="final">A Részletek leírása</target>
+			</trans-unit>
+<trans-unit id="femanager_invitation.title" approved="yes">
+				<source>Invitation</source>
+				<target state="final">Meghívó</target>
+			</trans-unit>
+<trans-unit id="femanager_invitation.description" approved="yes">
+				<source>Description of Invitation</source>
+				<target state="final">A Meghívó leírása</target>
+			</trans-unit>
+<trans-unit id="femanager_resendconfirmationmail.title" approved="yes">
+				<source>Resend Confirmation Mail</source>
+				<target state="final">Megerősítő e-mail újraküldése</target>
+			</trans-unit>
+<trans-unit id="femanager_resendconfirmationmail.description" approved="yes">
+				<source>Description of Resend Confirmation Mail</source>
+				<target state="final">A Megerősítő e-mail újraküldése leírása</target>
+			</trans-unit>
+  </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Adds Hungarian translations for all four language files, following the naming convention from `.crowdin.yml` (`%two_letters_code%.%original_file_name%`):

- `Resources/Private/Language/hu.locallang.xlf` (238 units)
- `Resources/Private/Language/hu.locallang_db.xlf` (133 units)
- `Resources/Private/Language/hu.locallang_mod.xlf` (16 units)
- `Resources/Private/Language/hu.locallang_csh_fe_users.xlf` (1 unit)

All `%s` placeholders preserved; format-string units (`m/d/Y`, `MM/DD/YYYY`) and proper nouns left unchanged. Files are valid XLIFF 1.0 with `target-language="hu"` and `state="final"` targets.

**How to test:** enable a Hungarian frontend language in a TYPO3 site configuration and check that femanager frontend forms, emails and the backend module show Hungarian labels.